### PR TITLE
Remove rails maximum version constraint from gemspec

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 Gem::Specification.new do |spec|
-  spec.add_dependency   'activerecord', ['>= 3.0', '< 4.1']
+  spec.add_dependency   'activerecord', ['>= 3.0']
   spec.add_dependency   'delayed_job',  ['>= 3.0', '< 4.1']
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = 'ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke'


### PR DESCRIPTION
To allow upgrades to Rails >= 6.1.